### PR TITLE
use server name instead of global name for embed fake replies

### DIFF
--- a/actions/messageCreate.action.js
+++ b/actions/messageCreate.action.js
@@ -383,11 +383,9 @@ async function editMessage(logger, client, message, matches, editPattern) {
       log("message reference")
       const reference = await message.fetchReference();
 
-      const member = message.guild?.members.cache.find((member => member.id == reference.author.id))
-      const tagged = member?.displayName ?? reference.author.displayName
-
+      const member = reference.member?.displayName ?? reference.author.displayName;
       const embed = new EmbedBuilder()
-        .setTitle(`replying to @${tagged}`)
+        .setTitle(`replying to @${member}`)
         .setURL(`https://discord.com/channels/${message.guildId}/${message.channelId}/${reference.id}`)
 
         if (reference.content) {

--- a/actions/messageCreate.action.js
+++ b/actions/messageCreate.action.js
@@ -382,8 +382,12 @@ async function editMessage(logger, client, message, matches, editPattern) {
     if (message.reference) {
       log("message reference")
       const reference = await message.fetchReference();
+
+      const member = message.guild?.members.cache.find((member => member.id == reference.author.id))
+      const tagged = member?.displayName ?? reference.author.displayName
+
       const embed = new EmbedBuilder()
-        .setTitle(`replying to @${reference.author.displayName}`)
+        .setTitle(`replying to @${tagged}`)
         .setURL(`https://discord.com/channels/${message.guildId}/${message.channelId}/${reference.id}`)
 
         if (reference.content) {


### PR DESCRIPTION
use server display name instead of global display name for embed fake replies (see #2)